### PR TITLE
limit guardian articles to 20 words

### DIFF
--- a/src/api-calls/guardian.js
+++ b/src/api-calls/guardian.js
@@ -9,7 +9,7 @@ const guardian = module.exports = {};
  * @param  {number} len number of words
  * @return {string} string containing < len words
  */
-guardian.cutOffSummary = (string, len = 50) => {
+guardian.cutOffSummary = (string, len = 20) => {
   const words = string.split(' ');
   if (words.length >= len) {
     return words.slice(0, len).join(' ') + '...';


### PR DESCRIPTION
articles are now a similar length to ny times articles. relates #78